### PR TITLE
Fix clear cursor when holding a ghost

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,10 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.0.6
+Date: 18/04/2021
+  Changes:
+    - Fixed a bug where the player could not use the clear cursor command while holding a ghost
+    - Updated to Factorio version 1.1
+---------------------------------------------------------------------------------------------------
 Version: 1.0.5
 Date: 18/02/2020
   Changes:

--- a/control.lua
+++ b/control.lua
@@ -37,6 +37,7 @@ script.on_event(defines.events.on_player_cursor_stack_changed, function(event)
                 return -- player has that item in their inventory, so they must have put it down themselves (by using 'clean cursor' action or clicking the item on the toolbelt)
             end
             player.cursor_ghost = last_held_item
+            memory_of(player).last_held_item_name = nil
         end
     end
 end)

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "GhostInHand",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "factorio_version": "1.1",
   "title": "Ghost In Hand",
   "author": "Jarcionek",

--- a/info.json
+++ b/info.json
@@ -1,7 +1,7 @@
 {
   "name": "GhostInHand",
   "version": "1.0.5",
-  "factorio_version": "0.18",
+  "factorio_version": "1.1",
   "title": "Ghost In Hand",
   "author": "Jarcionek",
   "description": "When a last held item is placed (either by you or by your construction robots) normally your hand would be emptied forcing you to pick that item again. This mod changes this behaviour, so that when you run out of items, a held item is replaced with its ghost.",

--- a/install.sh
+++ b/install.sh
@@ -1,16 +1,16 @@
 # prepare zip file
-mkdir GhostInHand_1.0.5
-cp info.json GhostInHand_1.0.5
-cp README.md GhostInHand_1.0.5
-cp LICENSE GhostInHand_1.0.5
-cp thumbnail.png GhostInHand_1.0.5
-cp *.lua GhostInHand_1.0.5
-cp -R locale GhostInHand_1.0.5
-cp changelog.txt GhostInHand_1.0.5
-zip -r GhostInHand_1.0.5{.zip,}
+mkdir GhostInHand_1.0.6
+cp info.json GhostInHand_1.0.6
+cp README.md GhostInHand_1.0.6
+cp LICENSE GhostInHand_1.0.6
+cp thumbnail.png GhostInHand_1.0.6
+cp *.lua GhostInHand_1.0.6
+cp -R locale GhostInHand_1.0.6
+cp changelog.txt GhostInHand_1.0.6
+zip -r GhostInHand_1.0.6{.zip,}
 
 # move zip to factorio mods folder (overriding existing one if present)
-mv GhostInHand_1.0.5.zip "/cygdrive/c/Users/${USER}/AppData/Roaming/Factorio/mods"
+mv GhostInHand_1.0.6.zip "/cygdrive/c/Users/${USER}/AppData/Roaming/Factorio/mods"
 
 # cleanup
-rm -r GhostInHand_1.0.5
+rm -r GhostInHand_1.0.6


### PR DESCRIPTION
This fixes a bug where the player could not use the clear cursor command to clear the cursor because this mod would place a ghost back in hand.

This also updates the factorio version to 1.1 and bumps the mod version to 1.0.6
